### PR TITLE
feat: enhance sales report with payment and room insights

### DIFF
--- a/src/app/admin/sales/page.tsx
+++ b/src/app/admin/sales/page.tsx
@@ -31,6 +31,9 @@ interface SalesData {
   incomeByRoom: Record<string, number>;
   mainTravelersByIdType: Record<string, number>;
   companionsByIdType: Record<string, number>;
+  paymentsByMethod: Record<string, number>;
+  topRoomLast5Days: string | null;
+  unsoldRoomsLast5Days: string[];
 }
 
 export default function SalesReportPage() {
@@ -145,6 +148,26 @@ export default function SalesReportPage() {
     ],
   };
 
+  const paymentMethodsChartData = {
+    labels: salesData ? Object.keys(salesData.paymentsByMethod) : [],
+    datasets: [
+      {
+        label: 'Ventas por Medio de Pago',
+        data: salesData ? Object.values(salesData.paymentsByMethod) : [],
+        backgroundColor: [
+          '#1E6C46',
+          '#FFE600',
+          '#2a9d8f',
+          '#e9c46a',
+          '#f4a261',
+          '#e76f51',
+        ],
+        borderColor: '#1E6C46',
+        borderWidth: 1,
+      },
+    ],
+  };
+
   const mainTravelersChartData = {
     labels: salesData ? Object.keys(salesData.mainTravelersByIdType) : [],
     datasets: [
@@ -242,6 +265,24 @@ export default function SalesReportPage() {
               <div className="bg-white p-6 rounded-lg shadow-md">
                 <h3 className="text-xl font-bold text-gray-800 mb-4">Ingresos por Habitación (Circular)</h3>
                 <Pie data={pieChartData} />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+              <div className="bg-white p-6 rounded-lg shadow-md">
+                <h3 className="text-xl font-bold text-gray-800 mb-4">Ventas por Medio de Pago</h3>
+                <Pie data={paymentMethodsChartData} />
+              </div>
+              <div className="bg-white p-6 rounded-lg shadow-md">
+                <h3 className="text-xl font-bold text-gray-800 mb-4">Informe Últimos 5 Días</h3>
+                <p>
+                  Habitación más vendida: {salesData.topRoomLast5Days || 'Sin ventas'}
+                </p>
+                <p>
+                  Habitaciones sin ventas:{' '}
+                  {salesData.unsoldRoomsLast5Days.length > 0
+                    ? salesData.unsoldRoomsLast5Days.join(', ')
+                    : 'Ninguna'}
+                </p>
               </div>
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- show payments by method in sales page
- report top-selling and unsold rooms from last five days

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fe9775ce88331a0c416792886e77f