### PR TITLE
feat: add cash register module models and API

### DIFF
--- a/src/app/api/caja/medios/route.ts
+++ b/src/app/api/caja/medios/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import PaymentMethod from '@/lib/models/paymentMethod.model';
+
+export async function GET() {
+  await dbConnect();
+  try {
+    const methods = await (PaymentMethod as any).find({}).sort({ name: 1 });
+    return NextResponse.json({ success: true, data: methods }, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+  }
+}

--- a/src/app/api/caja/transacciones/route.ts
+++ b/src/app/api/caja/transacciones/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import PaymentMethod from '@/lib/models/paymentMethod.model';
+import CashTransaction from '@/lib/models/cashTransaction.model';
+import User from '@/lib/models/user.model';
+import jwt from 'jsonwebtoken';
+
+export async function GET(req: NextRequest) {
+  await dbConnect();
+  try {
+    const tokenCookie = req.cookies.get('token');
+    if (!tokenCookie) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+    const decoded: any = jwt.verify(tokenCookie.value, process.env.JWT_SECRET!);
+    const userId = decoded.id;
+    const { searchParams } = new URL(req.url);
+    const query: any = { user: userId };
+    const tipo = searchParams.get('tipo');
+    const medioPago = searchParams.get('medioPago');
+    const habitacion = searchParams.get('habitacion');
+    const fechaInicio = searchParams.get('fechaInicio');
+    const fechaFin = searchParams.get('fechaFin');
+    if (tipo) query.type = tipo;
+    if (habitacion) query.room = habitacion;
+    if (medioPago) query.paymentMethod = medioPago;
+    if (fechaInicio || fechaFin) {
+      query.dateTime = {};
+      if (fechaInicio) query.dateTime.$gte = new Date(fechaInicio);
+      if (fechaFin) query.dateTime.$lte = new Date(fechaFin);
+    }
+    const transactions = await (CashTransaction as any).find(query).populate('paymentMethod', 'name');
+    return NextResponse.json({ success: true, data: transactions }, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  await dbConnect();
+  try {
+    const body = await req.json();
+    const {
+      referenciaPMS,
+      fechaHora,
+      tipo,
+      concepto,
+      monto,
+      medioPago,
+      habitacion,
+      usuarioCaja,
+    } = body;
+
+    let userId = usuarioCaja;
+    if (!userId) {
+      const tokenCookie = req.cookies.get('token');
+      if (!tokenCookie) {
+        return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+      }
+      const decoded: any = jwt.verify(tokenCookie.value, process.env.JWT_SECRET!);
+      userId = decoded.id;
+    }
+
+    // validate user exists
+    const user = await (User as any).findById(userId);
+    if (!user) {
+      return NextResponse.json({ success: false, error: 'Invalid user' }, { status: 400 });
+    }
+
+    let paymentMethod = await (PaymentMethod as any).findOne({ name: medioPago });
+    if (!paymentMethod) {
+      paymentMethod = await (PaymentMethod as any).create({ name: medioPago });
+    }
+
+    const txn = await (CashTransaction as any).create({
+      referencePMS: referenciaPMS,
+      dateTime: fechaHora ? new Date(fechaHora) : new Date(),
+      type: tipo,
+      concept: concepto,
+      amount: monto,
+      paymentMethod: paymentMethod._id,
+      room: habitacion,
+      user: userId,
+    });
+
+    return NextResponse.json({ success: true, data: txn }, { status: 201 });
+  } catch (error: any) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,6 +2,8 @@
 import mongoose from 'mongoose';
 import '@/lib/models/traveler.model';
 import '@/lib/models/companion.model';
+import '@/lib/models/paymentMethod.model';
+import '@/lib/models/cashTransaction.model';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 

--- a/src/lib/models/cashTransaction.model.ts
+++ b/src/lib/models/cashTransaction.model.ts
@@ -1,0 +1,16 @@
+import mongoose, { Schema, models } from 'mongoose';
+
+const cashTransactionSchema = new Schema({
+  dateTime: { type: Date, required: true, default: Date.now },
+  type: { type: String, enum: ['Ingreso', 'Salida'], required: true },
+  concept: { type: String, required: true },
+  amount: { type: Number, required: true },
+  paymentMethod: { type: Schema.Types.ObjectId, ref: 'PaymentMethod', required: true },
+  room: { type: String },
+  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  referencePMS: { type: String },
+}, { timestamps: true });
+
+const CashTransaction = models.CashTransaction || mongoose.model('CashTransaction', cashTransactionSchema);
+
+export default CashTransaction;

--- a/src/lib/models/paymentMethod.model.ts
+++ b/src/lib/models/paymentMethod.model.ts
@@ -1,0 +1,9 @@
+import mongoose, { Schema, models } from 'mongoose';
+
+const paymentMethodSchema = new Schema({
+  name: { type: String, required: true, unique: true },
+}, { timestamps: true });
+
+const PaymentMethod = models.PaymentMethod || mongoose.model('PaymentMethod', paymentMethodSchema);
+
+export default PaymentMethod;

--- a/src/lib/models/user.model.ts
+++ b/src/lib/models/user.model.ts
@@ -42,6 +42,10 @@ const userSchema = new Schema({
     type: Boolean,
     default: false,
   },
+  cashRole: {
+    type: String,
+    enum: ['Cajero', 'Supervisor', 'Administrador'],
+  },
 }, { timestamps: true });
 
 userSchema.pre("save", async function (next) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -29,6 +29,28 @@ declare interface User {
   isAdmin: boolean;
   isSuperUser: boolean;
   authorized: boolean;
+  cashRole?: 'Cajero' | 'Supervisor' | 'Administrador';
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+declare interface PaymentMethod {
+  _id?: string;
+  name: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+declare interface CashTransaction {
+  _id?: string;
+  dateTime: string;
+  type: 'Ingreso' | 'Salida';
+  concept: string;
+  amount: number;
+  paymentMethod: string | PaymentMethod;
+  room?: string;
+  user: string | User;
+  referencePMS?: string;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- add cashRole to user model to support cashier roles
- introduce PaymentMethod and CashTransaction mongoose models
- add REST endpoints for listing payment methods and creating/listing cash transactions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fff56f9d88331a5208fad26f88c53