### PR TITLE
fix: type Box model for findById

### DIFF
--- a/src/lib/models/box.model.ts
+++ b/src/lib/models/box.model.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema, Document } from 'mongoose';
+import mongoose, { Schema, Document, Model } from 'mongoose';
 
 export interface IBox extends Document {
   userId: mongoose.Schema.Types.ObjectId;
@@ -59,6 +59,8 @@ const boxSchema = new Schema(
   }
 );
 
-const Box = mongoose.models.Box || mongoose.model<IBox>('Box', boxSchema);
+const Box: Model<IBox> =
+  (mongoose.models.Box as Model<IBox>) ||
+  mongoose.model<IBox>('Box', boxSchema);
 
 export default Box;


### PR DESCRIPTION
## Summary
- type Box model with mongoose `Model` so `findById` is callable

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font `Oswald` and `Inter`)
- `npx tsc -p tsconfig.json --noEmit` (fails with existing type errors)


------
https://chatgpt.com/codex/tasks/task_e_68afa3eae3288331bc05500062bc0aaa