### PR TITLE
fix: adjust user lookup

### DIFF
--- a/src/app/api/box/payment/route.ts
+++ b/src/app/api/box/payment/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: 'Authorization header missing or invalid' }, { status: 401 });
     }
     const decoded = jwt.verify(token, SECRET as string) as { id: string };
-    const user = await User.findById(decoded.id).exec();
+    const user = await User.findById(decoded.id);
 
     if (!user) {
       return NextResponse.json({ message: "No find User" }, { status: 400 });


### PR DESCRIPTION
## Summary
- avoid calling `.exec()` on `User.findById` to satisfy Mongoose typings

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Failed to fetch fonts `Oswald`, `Inter`, missing modules `@mantine/core`, `react-redux`, `tabler-icons-react`)


------
https://chatgpt.com/codex/tasks/task_e_68afac8b9f348331aaccbc5e4841abd2